### PR TITLE
Add Laravel 5.5+ service auto-detection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,11 @@
     }
   },
   "extra": {
+    "laravel": {
+      "providers": [
+        "LaravelSpatial\\SpatialServiceProvider"
+      ]
+    },
     "branch-alias": {
       "dev-master": "1.0.x-dev"
     }


### PR DESCRIPTION
Laravel 5.5+ includes support for automatically registering service providers for project dependencies. This PR adds the `composer.json` entries needed to make this work.